### PR TITLE
課題種別設定ダイアログの挙動を変更

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -225,9 +225,9 @@ body, input, button {
 }
 .menu {
   float: right;
-  width: 100px;
   font-size: 18px;
-  margin-top: 10px;
+  line-height: 50px; /* same as header.height */
+  margin: 0 20px;
 }
 .intro {
   z-index: 100;

--- a/app/models/issue_type.rb
+++ b/app/models/issue_type.rb
@@ -1,2 +1,3 @@
 class IssueType < ActiveRecord::Base
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable
 
+  has_many :issue_types
+
   def self.find_for_backlog(auth)
     user = User.where(email: auth.info.email).first
 

--- a/app/views/home/_initial.html.erb
+++ b/app/views/home/_initial.html.erb
@@ -1,4 +1,7 @@
-<div class="neko-box intro">
+<div class="neko-box intro <%= show %>">
+	<div class="menu">
+		<a href="#" class="close">Close</a>
+	</div>
 	<div class="inner-intro">
 		<div class="step step-1">
 			<h1>Select a project</h1>
@@ -18,4 +21,27 @@
 		</div>
 	</div>
 </div>
-<script>$(function(){ neko.showMask(); util.centerize($('.intro')); });</script>
+<script>
+$(function(){
+	var showDialog = function () {
+		neko.showMask();
+		$('.intro').show();
+		util.centerize($('.intro'));
+	}
+
+	var hideDialog = function () {
+		$('.intro').hide();
+		neko.hideMask();
+	}
+
+	$('#settings_menu').click(function() {
+		showDialog();
+	});
+	$('.close').click(function() {
+		hideDialog();
+	});
+	if ($('.intro').hasClass('show')) {
+		showDialog();
+	}
+});
+</script>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,3 @@
 <%= render "home/main" %>
-<% if current_user.issue_types.empty? %>
-  <%= render "home/initial" %>
-<% end %>
+<%= render :partial => "home/initial", :locals => {:show => current_user.issue_types.empty? ? "show" : "hide"} %>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,5 @@
 <%= render "home/main" %>
-<% if true %>
+<% if current_user.issue_types.empty? %>
   <%= render "home/initial" %>
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
 	</div>
 	<% if user_signed_in? %>
 	<div class="menu">
+    <%= link_to "Settings", '#', {:id => 'settings_menu'} %>
 		<%= link_to "Sign out", destroy_user_session_path, {method: :delete, :class=>"logout"} %>
 	</div>
 	<% end %>


### PR DESCRIPTION
**やったこと**
- user と issue_type に関連を持たせ、当該ユーザーが課題種別をセット済みでないときダイアログを表示するようにした
- グローバルメニューに「Settings」メニューを追加し、いつでも設定ダイアログを表示できるようにした
- 設定ダイアログに「Close」リンクを追加して、ダイアログを非表示にできるようにした

**やらなかったこと**

Close リンクは「x」ボタンの方がいいかもしれないけど、後回しにする

refs: #34, https://hitomedia.backlog.jp/view/NL-1
